### PR TITLE
Add JavaScript to site theme (EscherLabs/Graphene#70)

### DIFF
--- a/app/Http/Controllers/UserDashboardController.php
+++ b/app/Http/Controllers/UserDashboardController.php
@@ -72,6 +72,15 @@ class UserDashboardController extends Controller
             ->header('Cache-Control','max-age='.$max_age);
     }
 
+    public function js(Request $request) {
+        $max_age = 604800; // Cache for 7 days
+        $site_js = config('app.site')->select('theme')->first()->theme->js;
+        return response($site_js,200)
+            ->header('Content-Type', 'text/javascript')
+            ->header('Pragma','cache')
+            ->header('Cache-Control','max-age='.$max_age);
+    }
+
     public function heartbeat(Request $request) {
         return ['status'=>true];
     }

--- a/app/Http/Middleware/Initialization.php
+++ b/app/Http/Middleware/Initialization.php
@@ -48,7 +48,7 @@ class Initialization
                 /* site data has been passed in for creation */
                 if(!empty($request->domain)&& !empty($request->name)){
                     $site = new Site($request->all());
-                    $site->theme = ['css' => '','icon'=>'file'];
+                    $site->theme = ['css' => '','icon'=>'file', 'js' => ''];
                     $site->templates = ['main'=>(object)[],'partials'=>(object)[
                         'footer'=>''
                     ]];

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,7 +14,7 @@ class DatabaseSeeder extends Seeder
         $site = new \App\Site;
         $site->domain = 'graphenedev.local';
         $site->name = 'LocalDev';
-        $site->theme = ['css' => '','icon'=>'file'];
+        $site->theme = ['css' => '','icon'=>'file', 'js' => ''];
         $site->templates = ['main'=>(object)[],'partials'=>(object)[
             'footer'=>''
         ]];

--- a/database/seeds/PortalMigration.php
+++ b/database/seeds/PortalMigration.php
@@ -31,7 +31,7 @@ class PortalMigration extends Seeder
             $site->domain = 'grapheneawsdev.escherlabs.com';
             $site->name = 'Graphene AWS';
             $bing_theme = json_decode(file_get_contents(base_path('public/assets/data').'/bing_theme.json'));
-            $site->theme = ['css'=>$bing_theme->css,'icon'=>'cloud'];
+            $site->theme = ['css'=>$bing_theme->css,'icon'=>'cloud', 'js' => ''];
             $site_theme_partials = [];
             foreach($bing_theme->partials as $partial) {
                 $site_theme_partials[$partial->name] = $partial->content;

--- a/public/assets/js/resources/site.js
+++ b/public/assets/js/resources/site.js
@@ -20,6 +20,7 @@ $.ajax({
 		$('#theme .col-sm-9').berry({fields: [
 			{label: 'Icon', name:'icon', required: true, inline: true},
 			{label: 'CSS', name:'css', type:'ace', inline: true, mode:'ace/mode/css'},
+			{label: 'JavaScript', name:'js', type:'ace', inline: true, mode:'ace/mode/javascript'},
 		],attributes:data.theme, actions:false, name:'theme'})
 
 		$('#cas_config .cas_config_form').berry({fields: [

--- a/resources/views/mustache/partials/core_engine.mustache
+++ b/resources/views/mustache/partials/core_engine.mustache
@@ -19,6 +19,7 @@
 {{/debug}}
 {{! Include stuff here that doesn't minify particularly well (like ACE and Nivo Slider)}}
 <script src="/assets/js/vendor/ace/ace.js?cb={{cache_bust_id}}" charset="utf-8"></script>
+<script src="/js?cb={{cache_bust_id}}"></script>
 {{#is_admin}}
     <script src='/assets/js/vendor/state-machine.js?cb={{cache_bust_id}}'></script>
     <script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ Route::get('/logout', '\App\Http\Controllers\Auth\LoginController@logout');
 /***** User Content *****/
 Route::get('/','UserDashboardController@index');
 Route::get('/css','UserDashboardController@css')->middleware('no.save.session');
+Route::get('/js','UserDashboardController@js')->middleware('no.save.session');
 Route::get('/app/{group}/{slug}', 'AppInstanceController@run');
 Route::get('/app/{group}','PageController@redirect')->middleware('no.save.session');
 Route::get('/link/{link}/{extra?}','LinkController@redirect')->where('extra','(.*)')->middleware('no.save.session');


### PR DESCRIPTION
Here’s my attempt at custom side-wide JavaScript support (EscherLabs/Graphene#70). There is at least one piece missing and that’s accounting for existing databases where the sites.theme JSON does not include the js key. I could add it [here](https://github.com/timroberson/Graphene/blob/b96368080172d5238422db6995fb2c822038951c/public/assets/js/resources/site.js#L24) like this:

```javascript
],attributes:_.assign({}, {js: ""}, data.theme), actions:false, name:'theme'})
```

On principle though, that seems a little messy. Personally, I would probably add it to a migration but I'm not sure how you feel about performing non-schema operations in a migration.

Let me know how you'd like to handle that piece and I can update the pull request.

Another thing that concerns me a little is that changes to the site JavaScript may not take effect immediately due to browser caching. I was thinking of storing an independent cache bust ID in the theme JSON and incrementing it whenever the JavaScript changes. Let me know your thoughts when you have a chance. Thank you!